### PR TITLE
feat(residents): Redesign Filter UI and Fix Page Layout

### DIFF
--- a/app/views/residents/index.php
+++ b/app/views/residents/index.php
@@ -17,8 +17,8 @@
 
     <div class="welcome"><h2>Residents Management</h2></div>
 
-    <main class="dashboard">
-        <div style="padding:0 2rem; max-width:1400px; margin:auto;">
+    <main class="dashboard dashboard-management">
+        <div style="padding:0 2rem; max-width:1400px; margin:auto; width: 100%;">
 
         <div class="page-actions-container">
                 <button id="addResidentBtn" class="action-button-link">
@@ -64,75 +64,85 @@
                  Filtered search results: <span id="filteredCount">0</span>
             </div>
 
-            <div class="filter-container" style="<?= $isPendingView ? 'display:none;' : '' ?>">
-                <div class="filter-group search-filter">
-                    <label for="searchInput">Search by Name</label>
-                    <input type="text" id="searchInput" placeholder="Enter name...">
-                </div>
-                 <div class="filter-group">
-                    <label for="houseNoFilter">House No.</label>
-                    <input type="text" id="houseNoFilter" placeholder="Enter house no...">
-                </div>
-                 <div class="filter-group">
-                    <label for="streetFilter">Street</label>
-                    <input type="text" id="streetFilter" placeholder="Enter street name...">
-                </div>
-                <div class="filter-group">
-                    <label for="purokFilter">Purok</label>
-                    <select id="purokFilter">
-                        <option value="">All</option>
-                        <?php
-                        if (!$isPendingView) {
-                            $puroks = array_unique(array_column($residents, 'purok'));
-                            sort($puroks);
-                            foreach($puroks as $p) if(!empty($p)) echo "<option value=\"".htmlspecialchars($p)."\">".htmlspecialchars($p)."</option>";
-                        }
-                        ?>
-                    </select>
-                </div>
-                <div class="filter-group">
-                    <label for="householdFilter">Head of Household</label>
-                    <select id="householdFilter">
-                        <option value="">All</option>
-                        <?php
-                        if (!$isPendingView) {
-                            foreach($household_heads as $head) {
-                                echo "<option value=\"".htmlspecialchars($head)."\">".htmlspecialchars($head)."</option>";
-                            }
-                        }
-                        ?>
-                    </select>
-                </div>
-                <div class="filter-group">
-                    <label for="statusFilter">Status</label>
-                    <select id="statusFilter">
-                        <option value="">All</option>
-                        <option value="Active">Active</option>
-                        <option value="Inactive">Inactive</option>
-                        <option value="Moved">Moved</option>
-                        <option value="Deceased">Deceased</option>
-                    </select>
-                </div>
-                <div class="filter-group">
-                    <label for="genderFilter">Gender</label>
-                    <select id="genderFilter">
-                        <option value="">All</option>
-                        <option value="Male">Male</option>
-                        <option value="Female">Female</option>
-                    </select>
-                </div>
-                <div class="filter-group age-filter">
-                    <label>Age Range</label>
-                    <div class="age-inputs">
-                        <input type="number" id="ageMin" placeholder="Min">
-                        <span>-</span>
-                        <input type="number" id="ageMax" placeholder="Max">
+            <div class="filter-wrapper" style="<?= $isPendingView ? 'display:none;' : '' ?>">
+                <div class="filter-container">
+                    <div class="filter-group search-filter">
+                        <label for="searchInput">Search by Name</label>
+                        <input type="text" id="searchInput" placeholder="Enter name...">
+                    </div>
+                    <div class="filter-group">
+                        <button id="toggleFiltersBtn" class="clear-btn" style="background-color: #17a2b8;">
+                            Advanced Filters <span class="material-icons">expand_more</span>
+                        </button>
                     </div>
                 </div>
-                <div class="filter-group">
-                    <button id="clearFiltersBtn" class="clear-btn">
-                        Clear Filters
-                    </button>
+
+                <div id="advanced-filters">
+                    <div class="filter-group">
+                        <label for="houseNoFilter">House No.</label>
+                        <input type="text" id="houseNoFilter" placeholder="Enter house no...">
+                    </div>
+                    <div class="filter-group">
+                        <label for="streetFilter">Street</label>
+                        <input type="text" id="streetFilter" placeholder="Enter street name...">
+                    </div>
+                    <div class="filter-group">
+                        <label for="purokFilter">Purok</label>
+                        <select id="purokFilter">
+                            <option value="">All</option>
+                            <?php
+                            if (!$isPendingView) {
+                                $puroks = array_unique(array_column($residents, 'purok'));
+                                sort($puroks);
+                                foreach($puroks as $p) if(!empty($p)) echo "<option value=\"".htmlspecialchars($p)."\">".htmlspecialchars($p)."</option>";
+                            }
+                            ?>
+                        </select>
+                    </div>
+                    <div class="filter-group">
+                        <label for="householdFilter">Head of Household</label>
+                        <select id="householdFilter">
+                            <option value="">All</option>
+                            <?php
+                            if (!$isPendingView) {
+                                foreach($household_heads as $head) {
+                                    echo "<option value=\"".htmlspecialchars($head)."\">".htmlspecialchars($head)."</option>";
+                                }
+                            }
+                            ?>
+                        </select>
+                    </div>
+                    <div class="filter-group">
+                        <label for="statusFilter">Status</label>
+                        <select id="statusFilter">
+                            <option value="">All</option>
+                            <option value="Active">Active</option>
+                            <option value="Inactive">Inactive</option>
+                            <option value="Moved">Moved</option>
+                            <option value="Deceased">Deceased</option>
+                        </select>
+                    </div>
+                    <div class="filter-group">
+                        <label for="genderFilter">Gender</label>
+                        <select id="genderFilter">
+                            <option value="">All</option>
+                            <option value="Male">Male</option>
+                            <option value="Female">Female</option>
+                        </select>
+                    </div>
+                    <div class="filter-group age-filter">
+                        <label>Age Range</label>
+                        <div class="age-inputs">
+                            <input type="number" id="ageMin" placeholder="Min">
+                            <span>-</span>
+                            <input type="number" id="ageMax" placeholder="Max">
+                        </div>
+                    </div>
+                    <div class="filter-group">
+                        <button id="clearFiltersBtn" class="clear-btn">
+                            Clear Filters
+                        </button>
+                    </div>
                 </div>
             </div>
 

--- a/public/assets/css/dashboard.css
+++ b/public/assets/css/dashboard.css
@@ -11,6 +11,13 @@
     overflow: hidden; /* Prevents scrollbars during animation */
 }
 
+/* NEW: Style for full-width management pages */
+.dashboard-management {
+    align-items: flex-start; /* Align content to the top */
+    justify-content: center; /* Keep content centered horizontally */
+}
+
+
 .card-grid {
     display: grid;
     grid-template-columns: repeat(2, 1fr);

--- a/public/assets/css/residents.css
+++ b/public/assets/css/residents.css
@@ -38,11 +38,14 @@
 /* =========================
    Enhanced Filter Styles
 ========================= */
-.filter-container {
+.filter-wrapper {
+    position: relative; /* Make this a positioning context */
     margin-top: 1.5rem;
+}
+
+.filter-container {
     display: flex;
     gap: 1.5rem;
-    flex-wrap: wrap;
     align-items: flex-end; /* Align items to the bottom */
     background: #f8f9fa;
     padding: 1rem;
@@ -50,6 +53,37 @@
     border: 1px solid #dee2e6;
     transition: background-color 0.3s, border-color 0.3s;
 }
+
+#advanced-filters {
+    display: none; /* Hidden by default */
+    position: absolute; /* Take it out of the document flow */
+    top: 100%; /* Position it right below the main filter bar */
+    left: 0;
+    right: 0;
+    z-index: 10;
+    background-color: #f8f9fa;
+    padding: 1.5rem;
+    border-radius: 0 0 12px 12px;
+    box-shadow: 0 8px 15px rgba(0,0,0,0.1);
+    border-top: 1px solid #dee2e6;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    animation: fadeIn 0.3s ease;
+}
+
+#toggleFiltersBtn .material-icons {
+    transition: transform 0.3s ease;
+}
+
+#toggleFiltersBtn.expanded .material-icons {
+    transform: rotate(180deg);
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
 
 .filter-group {
     display: flex;
@@ -129,6 +163,12 @@ body.dark-mode .filter-container {
     background-color: #1e1e2f;
     border-color: #4a5a6a;
 }
+
+body.dark-mode #advanced-filters {
+    background-color: #1e1e2f;
+    border-color: #4a5a6a;
+}
+
 body.dark-mode .filter-group label {
     color: #adb5bd;
 }
@@ -175,7 +215,7 @@ body.dark-mode .clear-btn:hover {
     font-weight: 500;
     transition: all 0.2s ease;
     cursor: pointer;
-    position: relative; 
+    position: relative;
     border: 1px solid transparent;
 }
 

--- a/public/assets/js/residents.js
+++ b/public/assets/js/residents.js
@@ -33,6 +33,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const basePath = '/iCensus-ent/public';
     const filteredResultsDiv = document.getElementById('filteredResults');
     const filteredCountSpan = document.getElementById('filteredCount');
+    const toggleFiltersBtn = document.getElementById('toggleFiltersBtn');
+    const advancedFilters = document.getElementById('advanced-filters');
 
     // --- STATE ---
     let currentPage = 1;
@@ -213,6 +215,12 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             alert('An error occurred while saving the resident.');
         }
+    });
+
+    toggleFiltersBtn.addEventListener('click', () => {
+        const isExpanded = advancedFilters.style.display === 'flex';
+        advancedFilters.style.display = isExpanded ? 'none' : 'flex';
+        toggleFiltersBtn.classList.toggle('expanded', !isExpanded);
     });
 
     // --- FINAL FIX FOR ALL FILTERS ---


### PR DESCRIPTION
This commit refactors the residents' filter section to improve UI/UX and corrects several layout issues on management pages.

Collapsible Advanced Filters:

- Replaced the static filter layout with a collapsible "Advanced Filters" panel.

- The main "Search by Name" input remains visible, while all other filters are toggled via an "Advanced Filters" button.

Layout Shift Fixes:

- The advanced filter panel is now positioned as an overlay, preventing the main table from shifting vertically when the panel is opened or closed.

- The main filter bar now maintains its full width, resolving the issue where it would shrink when the advanced panel was collapsed.

Main Content Alignment:

- Corrected the CSS for management-style pages (like Residents, Users, Logs) to align content to the top instead of centering it vertically. This fixes the "bunched up" layout.