### PR TITLE
fix(Residents): Correct encoder permissions and fix modal functionality

### DIFF
--- a/app/controllers/ResidentController.php
+++ b/app/controllers/ResidentController.php
@@ -129,6 +129,10 @@ class ResidentController {
                     break;
                 
                 case 'delete':
+                    if ($_SESSION['user']['role_name'] === 'Encoder') {
+                        echo json_encode(['status' => 'error', 'message' => 'You do not have permission to delete residents.']);
+                        exit;
+                    }
                     $resident_to_delete = $residentModel->find($_POST['id']);
                     if($resident_to_delete) {
                         $residentModel->delete($_POST['id']);

--- a/app/views/residents/index.php
+++ b/app/views/residents/index.php
@@ -363,6 +363,7 @@
     <script>
         const allResidentsData = <?= json_encode($residents); ?>;
         const isPendingView = <?= $isPendingView ? 'true' : 'false' ?>;
+        const userRole = '<?= htmlspecialchars($user['role_name']) ?>';
     </script>
     <script src="<?= $base_url ?>/assets/js/residents.js"></script>
     <script>

--- a/public/assets/js/residents.js
+++ b/public/assets/js/residents.js
@@ -62,7 +62,12 @@ document.addEventListener('DOMContentLoaded', () => {
         form.querySelectorAll('input, select').forEach(input => input.disabled = !editable);
         saveBtn.style.display = editable ? 'inline-flex' : 'none';
         editBtn.style.display = editable ? 'none' : 'inline-flex';
-        deleteBtn.style.display = editable ? 'none' : 'inline-flex';
+
+        if (editable || userRole === 'Encoder') {
+            deleteBtn.style.display = 'none';
+        } else {
+            deleteBtn.style.display = 'inline-flex';
+        }
     };
 
     const openModalForEdit = async (id) => {
@@ -98,7 +103,6 @@ document.addEventListener('DOMContentLoaded', () => {
         hiddenId.value = '';
         setFormEditable(true);
         editBtn.style.display = 'none';
-        deleteBtn.style.display = 'none';
         modalTitle.textContent = 'Add New Resident';
         modal.style.display = 'block';
     };
@@ -295,24 +299,26 @@ document.addEventListener('DOMContentLoaded', () => {
         handleFormSubmit(this);
     });
 
-    deleteBtn.addEventListener('click', async () => {
-        const id = hiddenId.value;
-        if (!id) return;
-        if (!confirm('Are you sure you want to delete this resident? This action cannot be undone.')) return;
-
-        const response = await fetch(`${basePath}/residents/process`, {
-            method: 'POST',
-            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-            body: new URLSearchParams({ action: 'delete', id: id })
+    if (deleteBtn) {
+        deleteBtn.addEventListener('click', async () => {
+            const id = hiddenId.value;
+            if (!id) return;
+            if (!confirm('Are you sure you want to delete this resident? This action cannot be undone.')) return;
+    
+            const response = await fetch(`${basePath}/residents/process`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                body: new URLSearchParams({ action: 'delete', id: id })
+            });
+            const result = await response.json();
+            if (result.status === 'success') {
+                modal.style.display = 'none';
+                showAjaxResult(result.message || 'Resident deleted successfully.', 'success');
+            } else {
+                alert(result.message || 'Failed to delete resident.');
+            }
         });
-        const result = await response.json();
-        if (result.status === 'success') {
-            modal.style.display = 'none';
-            showAjaxResult(result.message || 'Resident deleted successfully.', 'success');
-        } else {
-            alert('Failed to delete resident.');
-        }
-    });
+    }
     // --- END: AJAX FORM SUBMISSION LOGIC ---
 
     toggleFiltersBtn.addEventListener('click', () => {


### PR DESCRIPTION
This commit addresses a critical bug that prevented Encoders from adding or viewing resident information. It also properly implements the intended role-based permissions.

Fix Modal Bug: Resolves a JavaScript error that occurred for users with the "Encoder" role. The error was caused by the script failing to find the delete button, which prevented the resident modal from opening. The modal functionality for adding and viewing residents is now restored for all roles.

Implement UI Restriction: The delete button within the resident information modal is now correctly hidden from view for Encoders using JavaScript logic. This is achieved by passing the user's role from the PHP view to the script and dynamically adjusting the button's visibility.

Enforce Backend Security: A server-side check has been added to the ResidentController to explicitly block any delete requests submitted by an Encoder. This ensures data integrity even if the frontend is bypassed.