### PR TITLE
feat(analytics): Add chart management and persistent date filters

### DIFF
--- a/app/controllers/ChartController.php
+++ b/app/controllers/ChartController.php
@@ -13,6 +13,7 @@ class ChartController {
             echo json_encode(['status' => 'error', 'message' => 'Unauthorized']);
             exit;
         }
+        // This line is important for the log_action function to work
         $GLOBALS['db'] = new Database(require __DIR__ . '/../../config/database.php');
     }
 
@@ -77,6 +78,26 @@ class ChartController {
         exit;
     }
 
+    public function delete() {
+        $this->checkAuth();
+        header('Content-Type: application/json');
+
+        $chartId = $_POST['chart_id'] ?? null;
+        if (!$chartId) {
+            echo json_encode(['status' => 'error', 'message' => 'Chart ID is missing.']);
+            exit;
+        }
+
+        $chartModel = new Chart($GLOBALS['db']);
+        if ($chartModel->delete($chartId)) {
+            log_action('INFO', 'CHART_DELETED', "User deleted chart definition ID#{$chartId}.");
+            echo json_encode(['status' => 'success', 'message' => 'Chart deleted successfully!']);
+        } else {
+            echo json_encode(['status' => 'error', 'message' => 'Failed to delete chart.']);
+        }
+        exit;
+    }
+    
     public function get() {
         $this->checkAuth();
         header('Content-Type: application/json');
@@ -139,8 +160,7 @@ class ChartController {
                 exit;
             }
             
-            // --- MODIFIED: Add date range from GET params to the definition ---
-            if (isset($_GET['start_date']) && !empty($_GET['start_date']) && isset($_GET['end_date']) && !empty($_GET['end_date'])) {
+            if (!empty($_GET['start_date']) && !empty($_GET['end_date'])) {
                 $chartDef['start_date'] = $_GET['start_date'];
                 $chartDef['end_date'] = $_GET['end_date'];
             }
@@ -165,7 +185,7 @@ class ChartController {
     public function getUserCharts() {
         $this->checkAuth();
         header('Content-Type: application/json');
-
+        
         $chartModel = new Chart($GLOBALS['db']);
         $charts = $chartModel->findAllByUserId($_SESSION['user']['id']);
 

--- a/public/assets/js/dynamic_analytics.js
+++ b/public/assets/js/dynamic_analytics.js
@@ -30,7 +30,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
 const basePath = '/iCensus-ent/public';
 let grid;
-// Global state for sorting resident list
 let currentResidentList = [];
 let currentSort = { column: 'first_name', order: 'asc' };
 
@@ -45,17 +44,23 @@ function initializeDynamicDashboard() {
 
     document.getElementById('save-layout-btn').addEventListener('click', saveLayout);
     document.getElementById('reset-layout-btn').addEventListener('click', () => {
-        if(confirm('Are you sure you want to reset the layout? This will clear the current dashboard and reload with default positions.')) {
+        if(confirm('Are you sure you want to reset the layout? This will clear all chart settings, including saved date ranges.')) {
             localStorage.removeItem('chartLayout');
             localStorage.removeItem('visibleChartIds');
+            // Clear all chart-specific date ranges
+            Object.keys(localStorage).forEach(key => {
+                if (key.startsWith('chartDateRange_')) {
+                    localStorage.removeItem(key);
+                }
+            });
             location.reload();
         }
     });
 }
 
-async function loadUserCharts(startDate = null, endDate = null) {
+async function loadUserCharts() {
     if (grid) {
-        grid.removeAll(); // Clear existing charts before reloading
+        grid.removeAll(false); // Clear existing charts without destroying the grid
     }
     
     try {
@@ -84,10 +89,13 @@ async function loadUserCharts(startDate = null, endDate = null) {
                 
                 grid.addWidget(widgetHtml, gridOptions);
                 
+                // --- MODIFIED: Check for and apply saved date range for this chart ---
+                const savedDates = JSON.parse(localStorage.getItem(`chartDateRange_${chartId}`)) || {};
                 let dataUrl = `${basePath}/charts/data?chart_id=${chartId}`;
-                if (startDate && endDate) {
-                    dataUrl += `&start_date=${startDate}&end_date=${endDate}`;
+                if (savedDates.start && savedDates.end) {
+                    dataUrl += `&start_date=${savedDates.start}&end_date=${savedDates.end}`;
                 }
+
                 const dataResponse = await fetch(dataUrl);
                 const dataResult = await dataResponse.json();
 
@@ -197,7 +205,6 @@ function renderResidentList() {
     });
 }
 
-// --- MODIFIED: This function now accepts and uses the date filters ---
 async function showFilteredResidents(filterColumn, category, startDate, endDate) {
     const residentListContainer = document.getElementById('residentListContainer');
     residentListContainer.innerHTML = '<div class="list-placeholder">Loading residents...</div>';
@@ -208,7 +215,6 @@ async function showFilteredResidents(filterColumn, category, startDate, endDate)
     }
 
     const filterParams = new URLSearchParams({ [filterColumn]: category });
-    // --- THIS IS THE FIX ---
     if (startDate) filterParams.append('start_date', startDate);
     if (endDate) filterParams.append('end_date', endDate);
     
@@ -221,6 +227,34 @@ async function showFilteredResidents(filterColumn, category, startDate, endDate)
         console.error("Error fetching filtered residents:", error);
         currentResidentList = [];
         renderResidentList();
+    }
+}
+
+async function redrawDashboardChart(chartId, startDate, endDate) {
+    const chartDiv = document.getElementById(`chart-div-${chartId}`);
+    if (!chartDiv) return;
+
+    chartDiv.innerHTML = 'Loading...'; 
+
+    let dataUrl = `${basePath}/charts/data?chart_id=${chartId}`;
+    if (startDate && endDate) {
+        dataUrl += `&start_date=${startDate}&end_date=${endDate}`;
+    }
+
+    try {
+        const dataResponse = await fetch(dataUrl);
+        const dataResult = await dataResponse.json();
+
+        if (dataResult.status === 'success') {
+            chartDiv.chartData = dataResult.data;
+            chartDiv.chartType = dataResult.type;
+            drawChart(chartId, dataResult.type, dataResult.data);
+        } else {
+            chartDiv.innerHTML = `<div class="chart-error">Error loading data.</div>`;
+        }
+    } catch (error) {
+        console.error(`Failed to redraw chart ${chartId}:`, error);
+        chartDiv.innerHTML = `<div class="chart-error">An error occurred.</div>`;
     }
 }
 
@@ -263,8 +297,6 @@ function showChartDetailModal(chartId) {
                             const { row } = selection[0];
                             if (row !== null) {
                                 const category = chartObj.dataTable.getValue(row, 0);
-                                // --- THIS IS THE FIX ---
-                                // Pass the current date filter values to the resident list function
                                 showFilteredResidents(groupByColumn, category, startDateInput.value, endDateInput.value);
                                 chartObj.chart.setSelection([]);
                             }
@@ -283,6 +315,7 @@ function showChartDetailModal(chartId) {
         if (startDate && endDate) {
             localStorage.setItem(`chartDateRange_${chartId}`, JSON.stringify({ start: startDate, end: endDate }));
             redrawModalChart(startDate, endDate);
+            redrawDashboardChart(chartId, startDate, endDate); 
         } else {
             alert('Please select both a start and end date.');
         }
@@ -293,6 +326,7 @@ function showChartDetailModal(chartId) {
         endDateInput.value = '';
         localStorage.removeItem(`chartDateRange_${chartId}`);
         redrawModalChart(null, null);
+        redrawDashboardChart(chartId, null, null); 
     };
 
     modal.style.display = 'flex';

--- a/public/assets/js/manage_chart.js
+++ b/public/assets/js/manage_chart.js
@@ -64,20 +64,44 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // --- NEW: Event delegation for edit and delete buttons ---
+    // --- MODIFIED: Event delegation for edit and delete buttons ---
     chartList.addEventListener('click', async (e) => {
         const editBtn = e.target.closest('.edit-chart-btn');
         if (editBtn) {
             const chartId = editBtn.dataset.id;
             openChartBuilderForEdit(chartId);
+            return; // Stop further execution
         }
-        // Add delete logic here in the future
+
+        const deleteBtn = e.target.closest('.delete-chart-btn');
+        if (deleteBtn) {
+            const chartId = deleteBtn.dataset.id;
+            if (confirm('Are you sure you want to permanently delete this chart?')) {
+                try {
+                    const formData = new FormData();
+                    formData.append('chart_id', chartId);
+
+                    const response = await fetch(`${basePath}/charts/delete`, {
+                        method: 'POST',
+                        body: formData
+                    });
+                    const result = await response.json();
+
+                    if (result.status === 'success') {
+                        alert('Chart deleted successfully. The page will now reload.');
+                        location.reload();
+                    } else {
+                        alert('Error: ' + (result.message || 'Could not delete the chart.'));
+                    }
+                } catch (error) {
+                    console.error("Deletion failed:", error);
+                    alert('An unexpected error occurred.');
+                }
+            }
+        }
     });
 });
 
-/**
- * NEW: Function to open the chart builder in edit mode.
- */
 async function openChartBuilderForEdit(chartId) {
     const basePath = '/iCensus-ent/public';
     try {
@@ -90,12 +114,10 @@ async function openChartBuilderForEdit(chartId) {
         }
         const chartData = result.chart;
 
-        // Get modal elements
         const chartBuilderModal = document.getElementById('chartBuilderModal');
         const form = document.getElementById('chartBuilderForm');
         const filterContainer = document.getElementById('filterContainer');
 
-        // Reset form and set values
         form.reset();
         filterContainer.innerHTML = '';
         form.querySelector('#chartTitle').value = chartData.title;
@@ -103,7 +125,6 @@ async function openChartBuilderForEdit(chartId) {
         form.querySelector('#aggregateFunction').value = chartData.aggregate_function;
         form.querySelector('#groupByColumn').value = chartData.group_by_column;
         
-        // Add a hidden input for the chart ID
         let chartIdInput = form.querySelector('#chart_id');
         if (!chartIdInput) {
             chartIdInput = document.createElement('input');
@@ -114,7 +135,6 @@ async function openChartBuilderForEdit(chartId) {
         }
         chartIdInput.value = chartId;
         
-        // Hide the "Manage Charts" modal and show the builder
         document.getElementById('manageChartsModal').style.display = 'none';
         chartBuilderModal.style.display = 'block';
 

--- a/public/index.php
+++ b/public/index.php
@@ -117,6 +117,28 @@ switch ($route) {
         (new ChartController())->getUserCharts();
         break;
 
+    case 'charts/delete':
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        (new ChartController())->delete();
+        }
+        break;
+    case 'charts/get':
+        if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+        (new ChartController())->get();
+        }
+        break;
+    case 'charts/preview':
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        (new ChartController())->preview();
+        }
+        break;
+    case 'charts/data':
+        (new ChartController())->getData();
+        break;
+    case 'charts/user-charts':
+        (new ChartController())->getUserCharts();
+        break;    
+
     // --- Analytics Routes ---
     case 'analytics':
         (new AnalyticsController())->index();


### PR DESCRIPTION
- Implements Edit and Delete functionality for all user-created charts, accessible from the "Manage Charts" modal.
- Adds a persistent, per-chart date range filter to the expanded chart modal.
- The filter's state is saved and automatically applied to the corresponding chart on the main dashboard, ensuring data consistency between views.
- The resident list in the drill-down view now correctly respects the applied date range.
- Fixes a fatal PHP error in the ChartController that was preventing the dashboard from loading.