### PR TITLE
Fix(auth): Correct session initialization to resolve login bug

### DIFF
--- a/core/Auth.php
+++ b/core/Auth.php
@@ -50,6 +50,9 @@ class Auth {
             'two_fa' => $user['two_fa'] ?? 0
         ];
 
+        // --- BUG FIX: Add this line to initialize the session timer ---
+        $_SESSION['LAST_ACTIVITY'] = time();
+
         // UPDATED: Log the successful login event after setting the session
         log_action('INFO', 'USER_LOGIN_SUCCESS', "User '" . htmlspecialchars($username) . "' logged in successfully.");
 

--- a/core/init.php
+++ b/core/init.php
@@ -6,10 +6,13 @@ session_start();
 // This ensures redirects always go to the correct place.
 define('BASE_URL', '/iCensus-ent/public');
 
-// This function is for legacy use; direct checks in controllers are preferred.
-function checkAuth() {
-    if (!isset($_SESSION['user'])) {
-        // Use the defined BASE_URL for consistency
+// --- RECOMMENDED FIX: Add automatic authentication check ---
+// If the user session doesn't exist, redirect to login immediately.
+// This check runs on every page that includes this file.
+if (!isset($_SESSION['user'])) {
+    // We must check if the current request is for the login page itself
+    // to prevent an infinite redirect loop.
+    if (strpos($_SERVER['REQUEST_URI'], '/login') === false) {
         header("Location: " . BASE_URL . "/login");
         exit;
     }
@@ -25,7 +28,7 @@ if (isset($_SESSION['LAST_ACTIVITY']) && (time() - $_SESSION['LAST_ACTIVITY'] > 
     // Destroy the session
     session_destroy();
 
-    // Start a new, clean session for the login page
+    // Start a new, clean session for the login page    
     session_start();
 
     // Store a friendly message to show the user
@@ -38,3 +41,12 @@ if (isset($_SESSION['LAST_ACTIVITY']) && (time() - $_SESSION['LAST_ACTIVITY'] > 
 
 // Update last activity timestamp on each page load
 $_SESSION['LAST_ACTIVITY'] = time();
+
+// This function is for legacy use; direct checks in controllers are preferred.
+function checkAuth() {
+    if (!isset($_SESSION['user'])) {
+        // Use the defined BASE_URL for consistency
+        header("Location: " . BASE_URL . "/login");
+        exit;
+    }
+}


### PR DESCRIPTION
Resolves a bug where users were forced to log in twice after being logged out due to inactivity.

This was caused by an inconsistent session state originating from two issues:
1. The `login()` function in `core/Auth.php` was not setting the `LAST_ACTIVITY` session timestamp, leaving the session partially initialized.
2. The `core/init.php` script lacked a global authentication check, relying on individual controllers which could lead to inconsistent state management.

This commit applies the following fixes:
- Modifies `core/Auth.php` to set `$_SESSION['LAST_ACTIVITY']` immediately upon successful login.
- Adds an automatic, global authentication check to `core/init.php` to centralize security and ensure consistent session validation on every protected page.

These changes ensure the session is always in a valid and complete state, fixing the double-login issue and improving overall application security.